### PR TITLE
Expose properties and RPCRequest initializer for extensions

### DIFF
--- a/Web3/Classes/Core/Json/RPCRequest.swift
+++ b/Web3/Classes/Core/Json/RPCRequest.swift
@@ -21,6 +21,13 @@ public struct RPCRequest<Params: Codable>: Codable {
 
     /// The jsonrpc parameters
     public let params: Params
+    
+    public init(id: Int, jsonrpc: String, method: String, params: Params) {
+        self.id = id
+        self.jsonrpc = jsonrpc
+        self.method = method
+        self.params = params
+    }
 }
 
 public typealias BasicRPCRequest = RPCRequest<EthereumValue>

--- a/Web3/Classes/Core/Web3/Web3.swift
+++ b/Web3/Classes/Core/Web3/Web3.swift
@@ -75,7 +75,7 @@ public struct Web3 {
 
     public struct Net {
 
-        let properties: Properties
+        public let properties: Properties
 
         /**
          * Returns the current network id (chain id).
@@ -108,7 +108,7 @@ public struct Web3 {
 
     public struct Eth {
 
-        let properties: Properties
+        public let properties: Properties
 
         public func protocolVersion(response: @escaping Web3ResponseCompletion<String>) {
             let req = BasicRPCRequest(


### PR DESCRIPTION
This fixes some issues with extending Web3.Eth to add additional
methods. Eth.properties is not public and the only way to get to the
current provider. Additionally the auto-generated initializer for
RPCRequest struct was not accessible outside of the Web3 module.