### PR TITLE
Split EthereumTransaction and EthereumSignedTransaction

### DIFF
--- a/Example/Tests/TransactionTests/TransactionTests.swift
+++ b/Example/Tests/TransactionTests/TransactionTests.swift
@@ -28,23 +28,10 @@ class TransactionTests: QuickSpec {
                     return
                 }
 
-                var tx = EthereumTransaction(nonce: 0, gasPrice: EthereumQuantity(quantity: 21.gwei), gasLimit: 21000, to: to, value: EthereumQuantity(quantity: 1.eth), chainId: 3)
-
-                // This one is for the `it` closures as this tx will be signed once they run...
-                let fixedTx = tx
-
-                it("should be a non valid tx") {
-                    // Signature must not be valid now
-                    expect(fixedTx.verifySignature()) == false
-                }
-
-                let beforeHashValue = fixedTx.hashValue
-                it("should create correct hashValues") {
-                    expect(beforeHashValue) == fixedTx.hashValue
-                }
+                let tx = EthereumTransaction(nonce: 0, gasPrice: EthereumQuantity(quantity: 21.gwei), gasLimit: 21000, to: to, value: EthereumQuantity(quantity: 1.eth))
 
                 // Sign transaction with private key
-                let newTx = try? tx.sign(with: privateKey)
+                let newTx = try? tx.sign(with: privateKey, chainId: 3)
                 it("should not be nil") {
                     expect(newTx).toNot(beNil())
                 }
@@ -52,19 +39,17 @@ class TransactionTests: QuickSpec {
                 let expectedTransaction = "0xf86c808504e3b2920082520894867aeeeed428ed9ba7f97fc7e16f16dfcf02f375880de0b6b3a76400008029a099060c9146c68716da3a79533866dc941a03b171911d675f518c97a73882f7a6a0019167adb26b602501c954e7793e798407836f524b9778f5be6ebece5fc998c6"
 
                 it("should produce the expected rlp encoding") {
-                    expect(try? RLPEncoder().encode(tx.rlp()).hexString(prefix: true)) == expectedTransaction
+                    expect(try? RLPEncoder().encode(newTx!.rlp()).hexString(prefix: true)) == expectedTransaction
                 }
 
                 // Check validity
                 it("should be a valid tx") {
-                    expect(tx.verifySignature()) == true
+                    expect(newTx!.verifySignature()) == true
                 }
 
-                let afterHashValue = tx.hashValue
+                let afterHashValue = newTx!.hashValue
                 it("should create a different hashValue") {
-                    expect(afterHashValue) == tx.hashValue
-
-                    expect(beforeHashValue) != afterHashValue
+                    expect(tx.hashValue) != afterHashValue
                 }
             }
         }

--- a/Example/Tests/Web3Tests/Web3HttpTests.swift
+++ b/Example/Tests/Web3Tests/Web3HttpTests.swift
@@ -26,7 +26,7 @@ class Web3HttpTests: QuickSpec {
 
             context("web3 client version") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.clientVersion { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<EthereumValue>.Status.ok.rawValue
@@ -46,7 +46,7 @@ class Web3HttpTests: QuickSpec {
 
             context("net version") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.net.version { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<EthereumValue>.Status.ok.rawValue
@@ -66,7 +66,7 @@ class Web3HttpTests: QuickSpec {
 
             context("net peer count") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.net.peerCount { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<EthereumQuantity>.Status.ok.rawValue
@@ -86,7 +86,7 @@ class Web3HttpTests: QuickSpec {
 
             context("eth protocol version") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.protocolVersion { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -106,7 +106,7 @@ class Web3HttpTests: QuickSpec {
 
             context("eth syncing") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.syncing { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -136,7 +136,7 @@ class Web3HttpTests: QuickSpec {
 
             context("eth mining") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.mining { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -157,7 +157,7 @@ class Web3HttpTests: QuickSpec {
 
             context("eth hashrate") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.hashrate { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -178,7 +178,7 @@ class Web3HttpTests: QuickSpec {
 
             context("eth gas price") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.gasPrice { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -199,7 +199,7 @@ class Web3HttpTests: QuickSpec {
 
             context("eth accounts") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.accounts { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -220,7 +220,7 @@ class Web3HttpTests: QuickSpec {
 
             context("eth block number") {
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.blockNumber { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -248,7 +248,7 @@ class Web3HttpTests: QuickSpec {
                     return
                 }
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.getBalance(address: ethereumAddress, block: .block(4000000)) { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -276,7 +276,7 @@ class Web3HttpTests: QuickSpec {
                     return
                 }
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.getStorageAt(address: ethereumAddress, position: 0, block: .latest) { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -304,7 +304,7 @@ class Web3HttpTests: QuickSpec {
                     return
                 }
 
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     web3.eth.getTransactionCount(address: ethereumAddress, block: .block(4000000)) { response in
                         it("should be status ok") {
                             expect(response.status.rawValue) == Web3Response<String>.Status.ok.rawValue
@@ -323,7 +323,7 @@ class Web3HttpTests: QuickSpec {
             }
 
             context("eth get transaction count by hash") {
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     do {
                         try web3.eth.getBlockTransactionCountByHash(blockHash: .string("0x596f2d863a893392c55b72b5ba29e9ba67bdaa13c31765f9119e850a62565960")) { response in
                             it("should be status ok") {
@@ -349,7 +349,7 @@ class Web3HttpTests: QuickSpec {
             }
 
             context("eth get transaction count by number") {
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     firstly {
                         web3.eth.getBlockTransactionCountByNumber(block: .block(5397389))
                     }.done { count in
@@ -367,7 +367,7 @@ class Web3HttpTests: QuickSpec {
             }
 
             context("eth get uncle count by block hash") {
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     firstly {
                         try web3.eth.getUncleCountByBlockHash(blockHash: .string("0xd8cdd624c5b4c5323f0cb8536ca31de046e3e4a798a07337489bab1bb3d822f0"))
                     }.done { count in
@@ -385,7 +385,7 @@ class Web3HttpTests: QuickSpec {
             }
 
             context("eth get uncle count by block number") {
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     firstly {
                         web3.eth.getUncleCountByBlockNumber(block: .block(5397429))
                     }.done { count in
@@ -403,7 +403,7 @@ class Web3HttpTests: QuickSpec {
             }
 
             context("eth get code") {
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     firstly {
                         try web3.eth.getCode(address: EthereumAddress(hex: "0x2e704bF506b96adaC7aD1df0db461344146a4657", eip55: true), block: .block(5397525))
                     }.done { code in

--- a/README.md
+++ b/README.md
@@ -253,16 +253,15 @@ firstly {
     web3.eth.getTransactionCount(address: privateKey.address, block: .latest)
 }.then { nonce in
     Promise { seal in
-        var tx = try EthereumTransaction(
+        let tx = EthereumTransaction(
             nonce: nonce,
             gasPrice: EthereumQuantity(quantity: 21.gwei),
             gasLimit: 21000,
             to: EthereumAddress(hex: "0xC0866A1a0ed41e1aa75c932cA3c55fad847fd90D", eip55: true),
-            value: EthereumQuantity(quantity: 1.eth),
-            chainId: 1
+            value: EthereumQuantity(quantity: 1.eth)
         )
-        tx.sign(with: privateKey)
-        seal.resolve(tx, nil)
+        let signedTx = try tx.sign(with: privateKey, chainId: 1)
+        seal.resolve(signedTx, nil)
     }
 }.then { tx in
     web3.eth.sendRawTransaction(transaction: tx)
@@ -278,10 +277,9 @@ You can even add some promise extensions to `EthereumTransaction` like below:
 ```Swift
 extension EthereumTransaction {
 
-    func promiseSign(with: EthereumPrivateKey) -> Promise<EthereumTransaction> {
+    func promiseSign(with: EthereumPrivateKey, chainId: EthereumQuantity = 0) -> Promise<EthereumSignedTransaction> {
         return Promise { seal in
-            var tx = self
-            try tx.sign(with: with)
+            let tx = try self.sign(with: with, chainId: chainId)
             seal.resolve(tx, nil)
         }
     }
@@ -296,14 +294,13 @@ let privateKey = try! EthereumPrivateKey(hexPrivateKey: "0xa26da69ed1df3ba4bb2a2
 firstly {
     web3.eth.getTransactionCount(address: privateKey.address, block: .latest)
 }.then { nonce in
-    try EthereumTransaction(
+    EthereumTransaction(
         nonce: nonce,
         gasPrice: EthereumQuantity(quantity: 21.gwei),
         gasLimit: 21000,
         to: EthereumAddress(hex: "0xC0866A1a0ed41e1aa75c932cA3c55fad847fd90D", eip55: true),
-        value: EthereumQuantity(quantity: 1.eth),
-        chainId: 1
-    ).promiseSign(with: privateKey)
+        value: EthereumQuantity(quantity: 1.eth)
+    ).promiseSign(with: privateKey, chainId: 1)
 }.then { tx in
     web3.eth.sendRawTransaction(transaction: tx)
 }.done { hash in

--- a/Web3/Classes/Core/Transaction/EthereumTransaction.swift
+++ b/Web3/Classes/Core/Transaction/EthereumTransaction.swift
@@ -9,7 +9,116 @@
 import Foundation
 import BigInt
 
-public struct EthereumTransaction {
+public struct EthereumTransaction: Codable {
+    /// The number of transactions made prior to this one
+    public var nonce: EthereumQuantity?
+    
+    /// Gas price provided Wei
+    public var gasPrice: EthereumQuantity?
+    
+    /// Gas limit provided
+    public var gasLimit: EthereumQuantity?
+    
+    /// Address of the sender
+    public var from: EthereumAddress?
+    
+    /// Address of the receiver
+    public var to: EthereumAddress?
+    
+    /// Value to transfer provided in Wei
+    public var value: EthereumQuantity?
+    
+    /// Input data for this transaction
+    public var data: EthereumData
+    
+    // MARK: - Initialization
+    
+    /**
+     * Initializes a new instance of `EthereumTransaction` with the given values.
+     *
+     * - parameter nonce: The nonce of this transaction.
+     * - parameter gasPrice: The gas price for this transaction in wei.
+     * - parameter gasLimit: The gas limit for this transaction.
+     * - parameter from: The address to send from, required to send a transaction using sendTransaction()
+     * - parameter to: The address of the receiver.
+     * - parameter value: The value to be sent by this transaction in wei.
+     * - parameter data: Input data for this transaction. Defaults to [].
+     */
+    init(
+        nonce: EthereumQuantity? = nil,
+        gasPrice: EthereumQuantity? = nil,
+        gasLimit: EthereumQuantity? = nil,
+        from: EthereumAddress? = nil,
+        to: EthereumAddress? = nil,
+        value: EthereumQuantity? = nil,
+        data: EthereumData = EthereumData(bytes: [])
+    ) {
+        self.nonce = nonce
+        self.gasPrice = gasPrice
+        self.gasLimit = gasLimit
+        self.from = from
+        self.to = to
+        self.value = value
+        self.data = data
+    }
+    
+    
+    // MARK: - Convenient functions
+    
+    /**
+     * Signs this transaction with the given private key and returns an instance of `EthereumSignedTransaction`
+     *
+     * - parameter privateKey: The private key for the new signature.
+     * - parameter chainId: Optional chainId as described in EIP155.
+     */
+    public func sign(with privateKey: EthereumPrivateKey, chainId: EthereumQuantity = 0) throws -> EthereumSignedTransaction {
+        // These values are required for signing
+        guard let nonce = nonce, let gasPrice = gasPrice, let gasLimit = gasLimit, let value = value else {
+            throw EthereumSignedTransaction.Error.transactionInvalid
+        }
+        let rlp = RLPItem(
+            nonce: nonce,
+            gasPrice: gasPrice,
+            gasLimit: gasLimit,
+            to: to,
+            value: value,
+            data: data,
+            v: chainId,
+            r: 0,
+            s: 0
+        )
+        let rawRlp = try RLPEncoder().encode(rlp)
+        let signature = try privateKey.sign(message: rawRlp)
+        
+        let v: BigUInt
+        if chainId.quantity == 0 {
+            v = BigUInt(signature.v) + BigUInt(27)
+        } else {
+            let sigV = BigUInt(signature.v)
+            let big27 = BigUInt(27)
+            let chainIdCalc = (chainId.quantity * BigUInt(2) + BigUInt(8))
+            v = sigV + big27 + chainIdCalc
+        }
+        
+        let r = BigUInt(bytes: signature.r)
+        let s = BigUInt(bytes: signature.s)
+        
+        return EthereumSignedTransaction(
+            nonce: nonce,
+            gasPrice: gasPrice,
+            gasLimit: gasLimit,
+            to: to,
+            value: value,
+            data: data,
+            v: EthereumQuantity(quantity: v),
+            r: EthereumQuantity(quantity: r),
+            s: EthereumQuantity(quantity: s),
+            chainId: chainId
+        )
+    }
+}
+
+public struct EthereumSignedTransaction {
 
     // MARK: - Properties
 
@@ -23,7 +132,7 @@ public struct EthereumTransaction {
     public let gasLimit: EthereumQuantity
 
     /// Address of the receiver
-    public let to: EthereumAddress
+    public let to: EthereumAddress?
 
     /// Value to transfer provided in Wei
     public let value: EthereumQuantity
@@ -46,18 +155,18 @@ public struct EthereumTransaction {
     // MARK: - Initialization
 
     /**
-     * Initializes a new instance of `EthereumTransaction` with the given values.
+     * Initializes a new instance of `EthereumSignedTransaction` with the given values.
      *
      * - parameter nonce: The nonce of this transaction.
      * - parameter gasPrice: The gas price for this transaction in wei.
      * - parameter gasLimit: The gas limit for this transaction.
      * - parameter to: The address of the receiver.
      * - parameter value: The value to be sent by this transaction in wei.
-     * - parameter data: Input data for this transaction. Defaults to [].
-     * - parameter v: EC signature parameter v. Defaults to 0.
-     * - parameter r: EC signature parameter r. Defaults to 0.
-     * - parameter s: EC recovery ID. Defaults to 0.
-     * - parameter chainId: The chainId as described in EIP155. Mainnent: 1.
+     * - parameter data: Input data for this transaction.
+     * - parameter v: EC signature parameter v.
+     * - parameter r: EC signature parameter r.
+     * - parameter s: EC recovery ID.
+     * - parameter chainId: The chainId as described in EIP155. Mainnet: 1.
      *                      If set to 0 and v doesn't contain a chainId,
      *                      old style transactions are assumed.
      */
@@ -65,12 +174,12 @@ public struct EthereumTransaction {
         nonce: EthereumQuantity,
         gasPrice: EthereumQuantity,
         gasLimit: EthereumQuantity,
-        to: EthereumAddress,
+        to: EthereumAddress?,
         value: EthereumQuantity,
-        data: EthereumData = EthereumData(bytes: []),
-        v: EthereumQuantity = 0,
-        r: EthereumQuantity = 0,
-        s: EthereumQuantity = 0,
+        data: EthereumData,
+        v: EthereumQuantity,
+        r: EthereumQuantity,
+        s: EthereumQuantity,
         chainId: EthereumQuantity
     ) {
         self.nonce = nonce
@@ -93,47 +202,8 @@ public struct EthereumTransaction {
             self.chainId = chainId
         }
     }
-
+    
     // MARK: - Convenient functions
-
-    /**
-     * Signs this transaction with the given private key and discards old signatures if present.
-     *
-     * - parameter privateKey: The private key for the new signature.
-     */
-    @discardableResult
-    public mutating func sign(with privateKey: EthereumPrivateKey) throws -> EthereumTransaction {
-        let rawRlp = try RLPEncoder().encode(rlp(forSigning: true))
-        let signature = try privateKey.sign(message: rawRlp)
-
-        let v: BigUInt
-        if self.chainId.quantity == 0 {
-            v = BigUInt(signature.v) + BigUInt(27)
-        } else {
-            let sigV = BigUInt(signature.v)
-            let big27 = BigUInt(27)
-            let chainIdCalc = (chainId.quantity * BigUInt(2) + BigUInt(8))
-            v = sigV + big27 + chainIdCalc
-        }
-
-        let r = BigUInt(bytes: signature.r)
-        let s = BigUInt(bytes: signature.s)
-
-        self = EthereumTransaction(
-            nonce: self.nonce,
-            gasPrice: self.gasPrice,
-            gasLimit: self.gasLimit,
-            to: self.to,
-            value: self.value,
-            data: self.data,
-            v: EthereumQuantity(quantity: v),
-            r: EthereumQuantity(quantity: r),
-            s: EthereumQuantity(quantity: s),
-            chainId: self.chainId
-        )
-
-        return self
-    }
 
     public func verifySignature() -> Bool {
         let recId: BigUInt
@@ -146,8 +216,18 @@ public struct EthereumTransaction {
                 recId = v.quantity
             }
         }
-
-        if let _ = try? EthereumPublicKey(message: RLPEncoder().encode(rlp(forSigning: true)), v: EthereumQuantity(quantity: recId), r: r, s: s) {
+        let rlp = RLPItem(
+            nonce: nonce,
+            gasPrice: gasPrice,
+            gasLimit: gasLimit,
+            to: to,
+            value: value,
+            data: data,
+            v: chainId,
+            r: 0,
+            s: 0
+        )
+        if let _ = try? EthereumPublicKey(message: RLPEncoder().encode(rlp), v: EthereumQuantity(quantity: recId), r: r, s: s) {
             return true
         }
 
@@ -157,14 +237,53 @@ public struct EthereumTransaction {
     // MARK: - Errors
 
     public enum Error: Swift.Error {
-
         case transactionInvalid
         case rlpItemInvalid
         case signatureMalformed
     }
 }
 
-extension EthereumTransaction: RLPItemConvertible {
+extension RLPItem {
+    /**
+     * Create an RLPItem representing a transaction. The RLPItem must be an array of 9 items in the proper order.
+     *
+     * - parameter nonce: The nonce of this transaction.
+     * - parameter gasPrice: The gas price for this transaction in wei.
+     * - parameter gasLimit: The gas limit for this transaction.
+     * - parameter to: The address of the receiver.
+     * - parameter value: The value to be sent by this transaction in wei.
+     * - parameter data: Input data for this transaction.
+     * - parameter v: EC signature parameter v, or a EIP155 chain id for an unsigned transaction.
+     * - parameter r: EC signature parameter r.
+     * - parameter s: EC recovery ID.
+     */
+    init(
+        nonce: EthereumQuantity,
+        gasPrice: EthereumQuantity,
+        gasLimit: EthereumQuantity,
+        to: EthereumAddress?,
+        value: EthereumQuantity,
+        data: EthereumData,
+        v: EthereumQuantity,
+        r: EthereumQuantity,
+        s: EthereumQuantity
+    ) {
+        self = .array(
+            .bigUInt(nonce.quantity),
+            .bigUInt(gasPrice.quantity),
+            .bigUInt(gasLimit.quantity),
+            .bytes(to?.rawAddress ?? Bytes()),
+            .bigUInt(value.quantity),
+            .bytes(data.bytes),
+            .bigUInt(v.quantity),
+            .bigUInt(r.quantity),
+            .bigUInt(s.quantity)
+        )
+    }
+    
+}
+
+extension EthereumSignedTransaction: RLPItemConvertible {
 
     public init(rlp: RLPItem) throws {
         guard let array = rlp.array, array.count == 9 else {
@@ -190,54 +309,39 @@ extension EthereumTransaction: RLPItemConvertible {
             chainId: 0
         )
     }
-
+    
     public func rlp() -> RLPItem {
-        return rlp(forSigning: false)
-    }
-
-    public func rlp(forSigning: Bool) -> RLPItem {
-        let item: RLPItem
-
-        // Base rlp items
-        var rlpItems: [RLPItem] = [
-            .bigUInt(nonce.quantity),
-            .bigUInt(gasPrice.quantity),
-            .bigUInt(gasLimit.quantity),
-            .bytes(to.rawAddress),
-            .bigUInt(value.quantity),
-            .bytes(data.bytes)
-        ]
-        if forSigning && chainId.quantity != 0 {
-            // Add chain id for signing
-            rlpItems.append(
-                contentsOf: [
-                    // EIP 155: For signing and recovering: replace v with chainId and r and s with 0
-                    .bigUInt(chainId.quantity),
-                    .bigUInt(0),
-                    .bigUInt(0)
-                ]
-            )
-        } else {
-            // Add v, r and s values for already signed transactions
-            rlpItems.append(
-                contentsOf: [
-                    .bigUInt(v.quantity),
-                    .bigUInt(r.quantity),
-                    .bigUInt(s.quantity)
-                ]
-            )
-        }
-        item = .array(rlpItems)
-
-        return item
+        return RLPItem(
+            nonce: nonce,
+            gasPrice: gasPrice,
+            gasLimit: gasLimit,
+            to: to,
+            value: value,
+            data: data,
+            v: v,
+            r: r,
+            s: s
+        )
     }
 }
 
 // MARK: - Equatable
 
 extension EthereumTransaction: Equatable {
-
     public static func ==(_ lhs: EthereumTransaction, _ rhs: EthereumTransaction) -> Bool {
+        return lhs.nonce == rhs.nonce
+            && lhs.gasPrice == rhs.gasPrice
+            && lhs.gasLimit == rhs.gasLimit
+            && lhs.from == rhs.from
+            && lhs.to == rhs.to
+            && lhs.value == rhs.value
+            && lhs.data == rhs.data
+    }
+}
+
+extension EthereumSignedTransaction: Equatable {
+
+    public static func ==(_ lhs: EthereumSignedTransaction, _ rhs: EthereumSignedTransaction) -> Bool {
         return lhs.nonce == rhs.nonce
             && lhs.gasPrice == rhs.gasPrice
             && lhs.gasLimit == rhs.gasLimit
@@ -255,6 +359,15 @@ extension EthereumTransaction: Equatable {
 
 extension EthereumTransaction: Hashable {
 
+    public var hashValue: Int {
+        return hashValues(
+            nonce, gasPrice, gasLimit, from, to, value, data
+        )
+    }
+}
+
+extension EthereumSignedTransaction: Hashable {
+    
     public var hashValue: Int {
         return hashValues(
             nonce, gasPrice, gasLimit, to, value, data, v, r, s, chainId

--- a/Web3/Classes/Core/Web3/Web3.swift
+++ b/Web3/Classes/Core/Web3/Web3.swift
@@ -280,14 +280,14 @@ public struct Web3 {
         }
 
         public func sendRawTransaction(
-            transaction: EthereumTransaction,
+            transaction: EthereumSignedTransaction,
             response: @escaping Web3ResponseCompletion<EthereumData>
         ) {
             let req = BasicRPCRequest(
                 id: properties.rpcId,
                 jsonrpc: Web3.jsonrpc,
                 method: "eth_sendRawTransaction",
-                params: [transaction.rlp(forSigning: false)]
+                params: [transaction.rlp()]
             )
 
             properties.provider.send(request: req, response: response)

--- a/Web3/Classes/PromiseKit/Web3+PromiseKit.swift
+++ b/Web3/Classes/PromiseKit/Web3+PromiseKit.swift
@@ -174,7 +174,7 @@ public extension Web3.Eth {
         }
     }
 
-    public func sendRawTransaction(transaction: EthereumTransaction) -> Promise<EthereumData> {
+    public func sendRawTransaction(transaction: EthereumSignedTransaction) -> Promise<EthereumData> {
         return Promise { seal in
             self.sendRawTransaction(transaction: transaction) { response in
                 response.sealPromise(seal: seal)


### PR DESCRIPTION
This is an attempt to bring things a bit closer to web3.js. Technically
unsigned transactions do not require many of the fields before being
sent to the provider node for signing. When signing locally or
representing a signed transaction however, there are much stricter
rules. EthereumTransaction represents the pending transaction object,
and EthereumSignedTransaction represents the immutable signed version
of the transaction. This also adds the ability to represent Contract
creation transactions which do not have a to address.