### PR TITLE
Fix conversion of odd length hex strings to bytes

### DIFF
--- a/Example/Tests/ToolboxTests/String+Hex.swift
+++ b/Example/Tests/ToolboxTests/String+Hex.swift
@@ -1,0 +1,63 @@
+//
+//  String+Hex.swift
+//  Web3_Tests
+//
+//  Created by Josh Pyles on 5/25/18.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import Quick
+import Nimble
+@testable import Web3
+
+class StringBytesTests: QuickSpec {
+    
+    override func spec() {
+        describe("hex string to bytes conversions") {
+            context("hex string to bytes") {
+                it("should convert hex string with prefix") {
+                    let string = "0xFF"
+                    let stringBytes = try? string.hexBytes()
+                    expect(stringBytes).notTo(beNil())
+                    expect(stringBytes?.count) == 1
+                    expect(stringBytes?[0]) == UInt8(255)
+                }
+                it("should convert hex string without prefix") {
+                    let string = "FF"
+                    let stringBytes = try? string.hexBytes()
+                    expect(stringBytes).notTo(beNil())
+                    expect(stringBytes?.count) == 1
+                    expect(stringBytes?[0]) == UInt8(255)
+                }
+                it("should convert hex string without leading zero") {
+                    let string = "ABA"
+                    let stringBytes = try? string.hexBytes()
+                    expect(stringBytes).notTo(beNil())
+                    expect(stringBytes?.count) == 2
+                    expect(stringBytes?[0]) == UInt8(10)
+                }
+                it("should convert hex string with prefix and without leading zero") {
+                    let string = "0xABA"
+                    let stringBytes = try? string.hexBytes()
+                    expect(stringBytes).notTo(beNil())
+                    expect(stringBytes?.count) == 2
+                    expect(stringBytes?[0]) == UInt8(10)
+                }
+                it("should convert compact hex string without prefix") {
+                    let string = "5"
+                    let stringBytes = try? string.hexBytes()
+                    expect(stringBytes).notTo(beNil())
+                    expect(stringBytes?.count) == 1
+                    expect(stringBytes?[0]) == UInt8(5)
+                }
+                it("should not convert invalid hex string") {
+                    let string = ""
+                    let stringBytes = try? string.hexBytes()
+                    expect(stringBytes).notTo(beNil())
+                    expect(stringBytes?.count) == 0
+                }
+            }
+        }
+    }
+}
+

--- a/Example/Tests/Web3Tests/Web3HttpTests.swift
+++ b/Example/Tests/Web3Tests/Web3HttpTests.swift
@@ -422,7 +422,7 @@ class Web3HttpTests: QuickSpec {
             }
 
             context("eth call") {
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     firstly {
                         Promise { seal in
                             let call = try EthereumCall(
@@ -455,7 +455,7 @@ class Web3HttpTests: QuickSpec {
             }
 
             context("eth estimate gas") {
-                waitUntil { done in
+                waitUntil(timeout: 2.0) { done in
                     firstly {
                         Promise { seal in
                             let call = try EthereumCall(

--- a/Example/Web3.xcodeproj/project.pbxproj
+++ b/Example/Web3.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0EA5D3F32039123A0037C2BE /* UInt+BytesRepresentableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA5D3F22039123A0037C2BE /* UInt+BytesRepresentableTests.swift */; };
 		0EA5D3F7203912790037C2BE /* Web3HttpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EA5D3F6203912790037C2BE /* Web3HttpTests.swift */; };
 		E54BAE94B0A9A8565CD31D93 /* Pods_Web3_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD5947923E8841F929DE0AE8 /* Pods_Web3_Tests.framework */; };
+		E88B614F20B88F2E00C12395 /* String+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88B614E20B88F2E00C12395 /* String+Hex.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,6 +55,7 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		746C365C55131A708ACBAB71 /* Web3.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Web3.podspec; path = ../Web3.podspec; sourceTree = "<group>"; };
 		DA16060729F56349F6C9ADD3 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+		E88B614E20B88F2E00C12395 /* String+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Hex.swift"; sourceTree = "<group>"; };
 		FD5947923E8841F929DE0AE8 /* Pods_Web3_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Web3_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -99,6 +101,7 @@
 			children = (
 				0EA5D3F22039123A0037C2BE /* UInt+BytesRepresentableTests.swift */,
 				0E4503392059CAA1005C7D42 /* Int+ETH.swift */,
+				E88B614E20B88F2E00C12395 /* String+Hex.swift */,
 			);
 			path = ToolboxTests;
 			sourceTree = "<group>";
@@ -340,6 +343,7 @@
 				0E9C6B4E2039E32F000E7225 /* EthereumAddressTests.swift in Sources */,
 				0EA5D3EE2039121E0037C2BE /* RLPDecoderTests.swift in Sources */,
 				0EA5D3E62039120A0037C2BE /* EthereumCallParamsTests.swift in Sources */,
+				E88B614F20B88F2E00C12395 /* String+Hex.swift in Sources */,
 				0E9C6B4D2039E32F000E7225 /* TransactionTests.swift in Sources */,
 				0EA5D3F32039123A0037C2BE /* UInt+BytesRepresentableTests.swift in Sources */,
 				0EA5D3F7203912790037C2BE /* Web3HttpTests.swift in Sources */,

--- a/Web3/Classes/Core/Toolbox/String+HexBytes.swift
+++ b/Web3/Classes/Core/Toolbox/String+HexBytes.swift
@@ -9,29 +9,28 @@
 import Foundation
 
 extension String {
-
+    
+    /// Convert a hex string "0xFF" or "FF" to Bytes
     func hexBytes() throws -> Bytes {
-        guard self.count % 2 == 0 else {
-            throw StringHexBytesError.hexStringMalformed
-        }
-        var bytes = Bytes()
-
         var string = self
-
-        guard string.count >= 2 else {
-            return bytes
+        // Check if we have a complete byte
+        guard !string.isEmpty else {
+            return Bytes()
         }
-
-        let pre = string.startIndex
-        let post = string.index(string.startIndex, offsetBy: 2)
-        if String(string[pre..<post]) == "0x" {
-            // Remove prefix
-            string = String(string[post...])
+        
+        if string.count >= 2 {
+            let pre = string.startIndex
+            let post = string.index(string.startIndex, offsetBy: 2)
+            if String(string[pre..<post]) == "0x" {
+                // Remove prefix
+                string = String(string[post...])
+            }
         }
+        
+        //normalize string, since hex strings can omit leading 0
+        string = string.count % 2 == 0 ? string : "0" + string
 
-        try bytes.append(contentsOf: string.rawHex())
-
-        return bytes
+        return try string.rawHex()
     }
 
     func quantityHexBytes() throws -> Bytes {


### PR DESCRIPTION
Previously 0xF would fail while 0x0F would succeed. This PR essentially
just appends a leading zero to normalize the string when necessary.
Also adds some unit tests to verify it works in all the scenarios.