### PR TITLE
Fix crash when decoding empty array

### DIFF
--- a/Example/Tests/ABITests/ABITests.swift
+++ b/Example/Tests/ABITests/ABITests.swift
@@ -269,6 +269,17 @@ class ABITests: QuickSpec {
                         }
                     }
                     
+                    it("should decode empty dynamic arrays") {
+                        do {
+                            let string = "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000"
+                            let test = try ABI.decodeParameters(types: [.array(type: .string, length: nil)], from: string).first as? [String]
+                            let expected = [String]()
+                            expect(test).to(equal(expected))
+                        } catch {
+                            fail()
+                        }
+                    }
+                    
                 }
                 
                 context("when decoding fixed arrays") {
@@ -300,6 +311,17 @@ class ABITests: QuickSpec {
                             let string = "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006"
                             let test = try ABI.decodeParameters(types: [.array(type: .array(type: .uint32, length: 3), length: 2)], from: string).first as? [[UInt32]]
                             let expected: [[UInt32]] = [[1,2,3], [4,5,6]]
+                            expect(test).to(equal(expected))
+                        } catch {
+                            fail()
+                        }
+                    }
+                    
+                    it("should decode empty arrays") {
+                        do {
+                            let string = ""
+                            let test = try ABI.decodeParameters(types: [.array(type: .uint, length: 0)], from: string).first as? [String]
+                            let expected = [String]()
                             expect(test).to(equal(expected))
                         } catch {
                             fail()

--- a/Web3/Classes/Core/ABI/ABIDecoder.swift
+++ b/Web3/Classes/Core/ABI/ABIDecoder.swift
@@ -188,6 +188,7 @@ class ABIDecoder {
     }
     
     private class func decodeFixedArray(elementType: SolidityType, length: Int, from hexString: String) throws -> [Any] {
+        guard length > 0 else { return [] }
         let elementSize = hexString.count / length
         return try (0..<length).compactMap { n in
             if let elementString = hexString.substr(n * elementSize, elementSize) {


### PR DESCRIPTION
Ensures that length is greater than 0 before trying to divide by it