### PR TITLE
Fix decoder crash

### DIFF
--- a/Example/Tests/ABITests/ABITests.swift
+++ b/Example/Tests/ABITests/ABITests.swift
@@ -402,6 +402,16 @@ class ABITests: QuickSpec {
                     fail()
                 }
             }
+            
+            it("should throw an error when parsing wrong type") {
+                let response = "0x454f530000000000000000000000000000000000000000000000000000000000"
+                do {
+                    let _ = try ABI.decodeParameters(types: [.string], from: response)
+                    fail("Decoder should throw an error")
+                } catch {
+                    expect(error).toNot(beNil())
+                }
+            }
         }
         
     }

--- a/Web3/Classes/ContractABI/ABI/ABIDecoder.swift
+++ b/Web3/Classes/ContractABI/ABI/ABIDecoder.swift
@@ -41,6 +41,8 @@ class ABIDecoder {
         mutating func decode(from hexString: String, ranges: inout [Range<String.Index>]) throws {
             var substring = staticString
             if type.isDynamic {
+                // We expect the value in the tail
+                guard ranges.count > 0 else { throw Error.couldNotDecodeType(type: type, string: hexString) }
                 let range = ranges.removeFirst()
                 substring = String(hexString[range])
             }


### PR DESCRIPTION
Fixes #44, where trying to decode dynamic type when actually receiving fixed value will crash. This will now throw an error instead.