### PR TITLE
Make JSON-RPC error fields accessible

### DIFF
--- a/Web3/Classes/Core/Json/RPCResponse.swift
+++ b/Web3/Classes/Core/Json/RPCResponse.swift
@@ -25,10 +25,10 @@ public struct RPCResponse<Result: Codable>: Codable {
     public struct Error: Swift.Error, Codable {
 
         /// The error code
-        let code: Int
+        public let code: Int
 
         /// The error message
-        let message: String
+        public let message: String
         
         /// Description
         public var localizedDescription: String {


### PR DESCRIPTION
While doing some integration tests I noticed that these fields are not accessible on the error. This simply exposes them publicly.