### PR TITLE
Add an overloaded method to deploy a contract using an array of ABIEncodable

### DIFF
--- a/Web3/Classes/ContractABI/Contract/EthereumContract.swift
+++ b/Web3/Classes/ContractABI/Contract/EthereumContract.swift
@@ -109,6 +109,10 @@ public class DynamicContract: EthereumContract {
         return constructor?.invoke(byteCode: byteCode, parameters: parameters)
     }
     
+    public func deploy(byteCode: EthereumData, parameters: [ABIEncodable]) -> SolidityConstructorInvocation? {
+        return constructor?.invoke(byteCode: byteCode, parameters: parameters)
+    }
+    
     public func deploy(byteCode: EthereumData) -> SolidityConstructorInvocation? {
         return constructor?.invoke(byteCode: byteCode, parameters: [])
     }


### PR DESCRIPTION
Not being able to send an array of ABIEncodable parameters is big killer, this PR simply adds an overloaded method to enable using [ABIEncodable] for the parameters.