### PR TITLE
Fix 2/7 failing test cases by getting latest block

### DIFF
--- a/Tests/Web3Tests/Web3Tests/Web3HttpTests.swift
+++ b/Tests/Web3Tests/Web3Tests/Web3HttpTests.swift
@@ -215,7 +215,6 @@ class Web3HttpTests: QuickSpec {
 
                 waitUntil(timeout: 2.0) { done in
                     web3.eth.blockNumber { response in
-                        print("quant \(response.result)")
                         it("should be status ok") {
                             expect(response.status.isSuccess) == true
                         }


### PR DESCRIPTION
`A full-node running without archive mode will prune generated state to conserve disk space. This helps with the sync time of a node and greatly reduces storage and computation cost. Because of the way account and contract storage works in Ethereum, this means that only an archive node can serve API request for certain RPC methods older than 128 blocks.` thus the reason for these cases failing before. 