### PR TITLE
fix: websocket deadlock for high amounts of concurrency

### DIFF
--- a/Sources/Core/Toolbox/SynchronizedDictionary.swift
+++ b/Sources/Core/Toolbox/SynchronizedDictionary.swift
@@ -82,6 +82,12 @@ public final class SynchronizedDictionary<KeyType: Hashable, ValueType>: Sequenc
         }
     }
 
+    public func getValueAsync(key: KeyType, response: @escaping (_ value: ValueType?) -> Void) {
+        accessQueue.async {
+            response(self.internalDictionary[key])
+        }
+    }
+
     private func setValue(value: ValueType?, forKey key: KeyType) {
         accessQueue.async(flags: .barrier) {
             self.internalDictionary[key] = value

--- a/Sources/FoundationHTTP/Web3WebSocketProvider.swift
+++ b/Sources/FoundationHTTP/Web3WebSocketProvider.swift
@@ -303,8 +303,8 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
         // Reconnect
         try WebSocket.connect(to: wsUrl, configuration: .init(maxFrameSize: Int(min(Int64(UInt32.max), Int64(Int.max)))), on: wsEventLoopGroup) { ws in
             self.webSocket = ws
-        }.wait()
 
-        registerWebSocketListeners()
+            self.registerWebSocketListeners()
+        }.wait()
     }
 }

--- a/Sources/FoundationHTTP/Web3WebSocketProvider.swift
+++ b/Sources/FoundationHTTP/Web3WebSocketProvider.swift
@@ -91,7 +91,7 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
             self.timeoutNanoSeconds = UInt64(120 * 1_000_000_000)
         }
 
-        self.wsEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 4)
+        self.wsEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
         // Initial connect
         try reconnect()

--- a/Sources/FoundationHTTP/Web3WebSocketProvider.swift
+++ b/Sources/FoundationHTTP/Web3WebSocketProvider.swift
@@ -274,17 +274,19 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
     private func registerWebSocketListeners() {
         // Receive response
         webSocket.onText { ws, string in
-            guard let data = string.data(using: .utf8) else {
-                return
-            }
+            self.execQueue.async {
+                guard let data = string.data(using: .utf8) else {
+                    return
+                }
 
-            if let tmpCodable = try? self.decoder.decode(WebSocketOnTextTmpCodable.self, from: data) {
-                if let id = tmpCodable.id {
-                    self.pendingResponses[id] = string
-                    self.pendingRequests[id]?.signal()
-                } else if let params = tmpCodable.params {
-                    self.pendingSubscriptionResponses[params.subscription]?.append(string)
-                    self.currentSubscriptions[params.subscription]?.signal()
+                if let tmpCodable = try? self.decoder.decode(WebSocketOnTextTmpCodable.self, from: data) {
+                    if let id = tmpCodable.id {
+                        self.pendingResponses[id] = string
+                        self.pendingRequests[id]?.signal()
+                    } else if let params = tmpCodable.params {
+                        self.pendingSubscriptionResponses[params.subscription]?.append(string)
+                        self.currentSubscriptions[params.subscription]?.signal()
+                    }
                 }
             }
         }

--- a/Sources/FoundationHTTP/Web3WebSocketProvider.swift
+++ b/Sources/FoundationHTTP/Web3WebSocketProvider.swift
@@ -253,12 +253,10 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
 
     // MARK: - Helpers
 
-    private struct IdOnly: Codable {
-        let id: Int
-    }
+    private struct WebSocketOnTextTmpCodable: Codable {
+        let id: Int?
 
-    private struct SubscriptionIdOnly: Codable {
-        let params: Params
+        let params: Params?
 
         fileprivate struct Params: Codable {
             let subscription: String
@@ -272,12 +270,14 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
                 return
             }
 
-            if let idOnly = try? self.decoder.decode(IdOnly.self, from: data) {
-                self.pendingResponses[idOnly.id] = string
-                self.pendingRequests[idOnly.id]?.signal()
-            } else if let subscriptionIdOnly = try? self.decoder.decode(SubscriptionIdOnly.self, from: data) {
-                self.pendingSubscriptionResponses[subscriptionIdOnly.params.subscription]?.append(string)
-                self.currentSubscriptions[subscriptionIdOnly.params.subscription]?.signal()
+            if let tmpCodable = try? self.decoder.decode(WebSocketOnTextTmpCodable.self, from: data) {
+                if let id = tmpCodable.id {
+                    self.pendingResponses[id] = string
+                    self.pendingRequests[id]?.signal()
+                } else if let params = tmpCodable.params {
+                    self.pendingSubscriptionResponses[params.subscription]?.append(string)
+                    self.currentSubscriptions[params.subscription]?.signal()
+                }
             }
         }
 

--- a/Sources/FoundationHTTP/Web3WebSocketProvider.swift
+++ b/Sources/FoundationHTTP/Web3WebSocketProvider.swift
@@ -121,7 +121,6 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
             self.pendingRequests[replacedIdRequest.id] = responseSemaphore
 
             let promise = self.wsEventLoopGroup.next().makePromise(of: Void.self)
-            self.webSocket.send(String(data: body, encoding: .utf8) ?? "", promise: promise)
             promise.futureResult.whenComplete { result in
                 switch result {
                 case .success(_):
@@ -170,6 +169,9 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
                     return
                 }
             }
+
+            // Send Request through WebSocket once the Promise was set
+            self.webSocket.send(String(data: body, encoding: .utf8) ?? "", promise: promise)
         }
     }
     

--- a/Sources/FoundationHTTP/Web3WebSocketProvider.swift
+++ b/Sources/FoundationHTTP/Web3WebSocketProvider.swift
@@ -91,7 +91,7 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
             self.timeoutNanoSeconds = UInt64(120 * 1_000_000_000)
         }
 
-        self.wsEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        self.wsEventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 4)
 
         // Initial connect
         try reconnect()


### PR DESCRIPTION
For whatever reason WebSocket connections when used in highly concurrent applications generated pseudo deadlocks and waited ~4 seconds per request to process them. This PR fixes this issue by utilizing a non-blocking methodology of parallel computing (e.g.: completion handlers).