### PR TITLE
fix: SolidityType & ValueType conform to Sendable

### DIFF
--- a/Sources/ContractABI/ABI/SolidityType.swift
+++ b/Sources/ContractABI/ABI/SolidityType.swift
@@ -16,10 +16,10 @@ import BigInt
 /// - type: A regular single type
 /// - array: A homogenous collection of a type with an optional length
 /// - tuple: A collection of types
-public indirect enum SolidityType {
+public indirect enum SolidityType: Sendable {
     
     /// Solidity Base Types
-    public enum ValueType {
+    public enum ValueType: Sendable {
         
         /// unsigned integer type of M bits, 0 < M <= 256, M % 8 == 0. e.g. uint32, uint8, uint256.
         case uint(bits: UInt16)

--- a/Sources/Core/Json/EthereumBlockObject.swift
+++ b/Sources/Core/Json/EthereumBlockObject.swift
@@ -10,7 +10,7 @@ import Foundation
 /**
  * A block as returned by an Ethereum node.
  */
-public struct EthereumBlockObject: Codable {
+public struct EthereumBlockObject: Codable, Sendable {
 
     /// The block number. nil when its a pending block.
     public let number: EthereumQuantity?
@@ -72,7 +72,7 @@ public struct EthereumBlockObject: Codable {
     /**
      * Represents a transaction as either a hash or an object.
      */
-    public struct Transaction: Codable {
+    public struct Transaction: Codable, Sendable {
 
         /// The transaction as an object
         public let object: EthereumTransactionObject?

--- a/Sources/Core/Json/EthereumCall.swift
+++ b/Sources/Core/Json/EthereumCall.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EthereumCall: Codable {
+public struct EthereumCall: Codable, Sendable {
 
     /// The address the transaction is sent from.
     public let from: EthereumAddress?
@@ -46,7 +46,7 @@ public struct EthereumCall: Codable {
     }
 }
 
-public struct EthereumCallParams: Codable {
+public struct EthereumCallParams: Codable, Sendable {
 
     /// The actual call parameters
     public let call: EthereumCall

--- a/Sources/Core/Json/EthereumData.swift
+++ b/Sources/Core/Json/EthereumData.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EthereumData: BytesConvertible {
+public struct EthereumData: BytesConvertible, Sendable {
 
     public let bytes: Bytes
 

--- a/Sources/Core/Json/EthereumLogObject.swift
+++ b/Sources/Core/Json/EthereumLogObject.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EthereumLogObject: Codable {
+public struct EthereumLogObject: Codable, Sendable {
 
     /// true when the log was removed, due to a chain reorganization. false if its a valid log.
     public let removed: Bool?

--- a/Sources/Core/Json/EthereumQuantity.swift
+++ b/Sources/Core/Json/EthereumQuantity.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import BigInt
+@preconcurrency import BigInt
 
-public struct EthereumQuantity {
+public struct EthereumQuantity: Sendable {
 
     public let quantity: BigUInt
 

--- a/Sources/Core/Json/EthereumQuantityTag.swift
+++ b/Sources/Core/Json/EthereumQuantityTag.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 import CryptoSwift
-import BigInt
+@preconcurrency import BigInt
 
-public struct EthereumQuantityTag {
+public struct EthereumQuantityTag: Sendable {
 
-    public enum TagType {
+    public enum TagType: Sendable {
 
         case block(BigUInt)
         case latest

--- a/Sources/Core/Json/EthereumTransactionObject.swift
+++ b/Sources/Core/Json/EthereumTransactionObject.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct EthereumTransactionObject: Codable {
+public struct EthereumTransactionObject: Codable, Sendable {
 
     /// 32 Bytes - hash of the transaction.
     public let hash: EthereumData

--- a/Sources/Core/Json/EthereumValue.swift
+++ b/Sources/Core/Json/EthereumValue.swift
@@ -10,12 +10,12 @@ import Foundation
 /**
  * A `Codable`, Ethereum representable value.
  */
-public struct EthereumValue: Codable {
+public struct EthereumValue: Codable, Sendable {
 
     /// The internal type of this value
     public let valueType: ValueType
 
-    public enum ValueType {
+    public enum ValueType: Sendable {
 
         /// A string value
         case string(String)

--- a/Sources/Core/Transaction/EthereumAddress.swift
+++ b/Sources/Core/Transaction/EthereumAddress.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CryptoSwift
 
-public struct EthereumAddress {
+public struct EthereumAddress: Sendable {
 
     // MARK: - Properties
 

--- a/Sources/Core/Transaction/EthereumTransaction.swift
+++ b/Sources/Core/Transaction/EthereumTransaction.swift
@@ -180,7 +180,7 @@ public struct EthereumTransaction: Codable {
             throw EthereumSignedTransaction.Error.chainIdNotSet(msg: "EIP1559 transactions need a chainId")
         }
         
-        var messageToSign = try self.messageToSign(chainId: chainId)
+        let messageToSign = try self.messageToSign(chainId: chainId)
         let signature = try privateKey.sign(message: messageToSign)
 
         let v = BigUInt(signature.v)


### PR DESCRIPTION
These values are safe to send around and during wrapped async calls are required to be sendable in swift 6. Current workaround is to do this:

`extension SolidityType: @unchecked Sendable {}`