### PR TITLE
fix empty string responses

### DIFF
--- a/Sources/ContractABI/ABI/ABIConvertible.swift
+++ b/Sources/ContractABI/ABI/ABIConvertible.swift
@@ -207,6 +207,8 @@ extension String: ABIConvertible {
     public init?(hexString: String) {
         if let data = Data(hexString: hexString) {
             self.init(data: data, encoding: .utf8)
+        } else if hexString == String(repeating: "0", count: 64) {
+            self = ""
         } else {
             return nil
         }


### PR DESCRIPTION
this PR fixes an issue where empty strings returned from contracts (64 `0`´s), failed to decode properly.