### PR TITLE
Fix: Web3WebSocketProvider deinitialization crash

### DIFF
--- a/Sources/FoundationHTTP/Web3WebSocketProvider.swift
+++ b/Sources/FoundationHTTP/Web3WebSocketProvider.swift
@@ -96,7 +96,11 @@ public class Web3WebSocketProvider: Web3Provider, Web3BidirectionalProvider {
 
     deinit {
         closed = true
-        _ = webSocket.close(code: .goingAway)
+
+        // Close connection if already initialized
+        if let webSocket {
+          _ = webSocket.close(code: .goingAway)
+        }
 
         // As described in https://github.com/apple/swift-nio/issues/2371
         try? wsEventLoopGroup.syncShutdownGracefully()


### PR DESCRIPTION
## Issue Description

When `Web3WebSocketProvider` fails to establish a connection during initialization (due to wrong URL or connectivity issues), it properly throws an error as expected. However, when the instance is later deallocated, it crashes with a fatal error:

```
Thread 1: Fatal error: Unexpectedly found nil while implicitly unwrapping an Optional value
```

This occurs because:
1. The `webSocket` property is declared as an implicitly unwrapped optional (`WebSocket!`)
2. If initialization fails before `webSocket` is assigned, it remains `nil`
3. During deinitialization, the code unconditionally attempts to access this nil value

## Fix

Added a nil check before attempting to close the WebSocket connection:

```swift
deinit {
    closed = true
    
    // Close connection if already initialized
    if let webSocket {
        _ = webSocket.close(code: .goingAway)
    }

    // As described in https://github.com/apple/swift-nio/issues/2371
    try? wsEventLoopGroup.syncShutdownGracefully()
}
```

This change ensures the `Web3WebSocketProvider` can be safely deallocated even when a connection couldn't be established, improving error handling and preventing crashes during cleanup.